### PR TITLE
🐛 Declare main edflex table to fix course deletion

### DIFF
--- a/db/install.xml
+++ b/db/install.xml
@@ -4,6 +4,20 @@
        xsi:noNamespaceSchemaLocation="../../../lib/xmldb/xmldb.xsd"
 >
     <TABLES>
+        <TABLE NAME="edflex" COMMENT="Main table for the edflex activity module instances.">
+            <FIELDS>
+                <FIELD NAME="id" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="true"/>
+                <FIELD NAME="course" TYPE="int" LENGTH="10" NOTNULL="true" DEFAULT="0" SEQUENCE="false" COMMENT="ID of the course this activity belongs to."/>
+                <FIELD NAME="name" TYPE="char" LENGTH="255" NOTNULL="true" SEQUENCE="false" COMMENT="Name of the activity instance."/>
+                <FIELD NAME="intro" TYPE="text" NOTNULL="false" SEQUENCE="false" COMMENT="Description of the activity instance."/>
+                <FIELD NAME="introformat" TYPE="int" LENGTH="4" NOTNULL="true" DEFAULT="0" SEQUENCE="false" COMMENT="Format of the intro field."/>
+                <FIELD NAME="timemodified" TYPE="int" LENGTH="10" NOTNULL="true" DEFAULT="0" SEQUENCE="false" COMMENT="Unix timestamp of the last modification."/>
+            </FIELDS>
+            <KEYS>
+                <KEY NAME="primary" TYPE="primary" FIELDS="id"/>
+                <KEY NAME="fk_course" TYPE="foreign" FIELDS="course" REFTABLE="course" REFFIELDS="id"/>
+            </KEYS>
+        </TABLE>
         <TABLE NAME="edflex_scorm" COMMENT="Stores the extra data for edflex scorm activities.">
             <FIELDS>
                 <FIELD NAME="id" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="true"/>

--- a/db/upgrade.php
+++ b/db/upgrade.php
@@ -30,5 +30,35 @@
  * @return bool
  */
 function xmldb_edflex_upgrade(int $oldversion): bool {
+    global $DB;
+
+    $dbman = $DB->get_manager();
+
+    if ($oldversion < 2026062400) {
+        // Define table edflex to be created.
+        $table = new xmldb_table('edflex');
+
+        // Adding fields to table edflex.
+        $table->add_field('id', XMLDB_TYPE_INTEGER, '10', null, XMLDB_NOTNULL, XMLDB_SEQUENCE, null);
+        $table->add_field('course', XMLDB_TYPE_INTEGER, '10', null, XMLDB_NOTNULL, null, '0');
+        $table->add_field('name', XMLDB_TYPE_CHAR, '255', null, XMLDB_NOTNULL, null, null);
+        $table->add_field('intro', XMLDB_TYPE_TEXT, null, null, null, null, null);
+        $table->add_field('introformat', XMLDB_TYPE_INTEGER, '4', null, XMLDB_NOTNULL, null, '0');
+        $table->add_field('timemodified', XMLDB_TYPE_INTEGER, '10', null, XMLDB_NOTNULL, null, '0');
+
+        // Adding keys to table edflex.
+        $table->add_key('primary', XMLDB_KEY_PRIMARY, ['id']);
+        $table->add_key('fk_course', XMLDB_KEY_FOREIGN, ['course'], 'course', ['id']);
+
+        // Conditionally launch create table for edflex.
+        // A client may have created the table manually as an emergency workaround.
+        if (!$dbman->table_exists($table)) {
+            $dbman->create_table($table);
+        }
+
+        // Edflex savepoint reached.
+        upgrade_mod_savepoint(true, 2026062400, 'edflex');
+    }
+
     return true;
 }

--- a/lib.php
+++ b/lib.php
@@ -71,7 +71,15 @@ function edflex_update_instance($moduleinstance, $mform = null) {
  * @return bool
  */
 function edflex_delete_instance($id) {
-    return false;
+    global $DB;
+
+    if (!$DB->get_record('edflex', ['id' => $id])) {
+        return false;
+    }
+
+    $DB->delete_records('edflex', ['id' => $id]);
+
+    return true;
 }
 
 

--- a/version.php
+++ b/version.php
@@ -25,7 +25,7 @@
 defined('MOODLE_INTERNAL') || die();
 
 $plugin->component = 'mod_edflex';
-$plugin->release = 'v1.0.0';
+$plugin->release = 'v1.0.1';
 $plugin->version = 2026062400;
 $plugin->requires = 2022041900;
 $plugin->maturity = MATURITY_STABLE;

--- a/version.php
+++ b/version.php
@@ -26,7 +26,7 @@ defined('MOODLE_INTERNAL') || die();
 
 $plugin->component = 'mod_edflex';
 $plugin->release = 'v1.0.0';
-$plugin->version = 2025120118;
+$plugin->version = 2026062400;
 $plugin->requires = 2022041900;
 $plugin->maturity = MATURITY_STABLE;
 $plugin->dependencies = [


### PR DESCRIPTION
## 🎯 Purpose of this Pull Request

The plugin never declared its mandatory main `edflex` table. Moodle's core `remove_course_contents()` runs `SELECT … FROM mdl_{modname}` for every installed module on course deletion, so the missing table raised a `dmlreadexception` that broke deletion of **any** course platform-wide — even courses that never used Edflex.

Related to #5

---

## 📝 Summary of Changes

- Declare the main `edflex` table in `db/install.xml` (`id`, `course`, `name`, `intro`, `introformat`, `timemodified`).
- Create the table on already-installed v1.0.0 instances in `db/upgrade.php`, guarded by `table_exists()`; bump `$plugin->version` to `2026062400`.
- `edflex_delete_instance()` now purges its `{edflex}` row instead of returning `false`.

---

## ✔️ Moodle Plugin Checklist

### **Code Quality & Standards**
- [x] Code follows Moodle coding guidelines
- [x] PHPDoc blocks updated where needed
- [x] No debug statements left
- [x] Namespace and file structure follow Moodle plugin conventions

### **Functional Changes**
- [x] Upgrade steps added to `db/upgrade.php`

### **Database & Files**
- [x] DB schema changes added to `db/install.xml` and `db/upgrade.php`

---

## 🧪 Testing

### **Manual Tests**
- On an instance upgraded from v1.0.0: run the plugin upgrade, confirm the `edflex` table is created.
- Create any course (no Edflex activity needed) and delete it → succeeds, no `dmlreadexception`.
- Fresh install: confirm the `edflex` table is present after install.

### **Automated Tests**
- No unit test added — change is schema/upgrade only; `moodle-plugin-ci` (validate + savepoints) covers it on CI.

---

## 🔄 Regression Risk

Additive schema only. Touches the upgrade path for existing installs and the course-deletion path (the fix target). Low risk.

---

## 🔗 Additional Notes

- Moodle plugin CI is expected to catch a missing main table — worth understanding why it passed before.
- Follow-up, out of scope: add backup/restore + privacy provider once the `edflex` table actually stores instance data (today `edflex_add_instance` still returns `false`, so no data is written yet).
