### PR TITLE
✨ Add backup/restore, view capability and viewed event

### DIFF
--- a/backup/moodle2/backup_edflex_activity_task.class.php
+++ b/backup/moodle2/backup_edflex_activity_task.class.php
@@ -1,0 +1,75 @@
+<?php
+// This file is part of Moodle - https://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <https://www.gnu.org/licenses/>.
+
+/**
+ * Backup task for mod_edflex.
+ *
+ * @package     mod_edflex
+ * @copyright   2025 Edflex <support@edflex.com>
+ * @license     https://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+defined('MOODLE_INTERNAL') || die();
+
+require_once($CFG->dirroot . '/mod/edflex/backup/moodle2/backup_edflex_stepslib.php');
+
+/**
+ * Provides the steps to perform one complete backup of the edflex instance.
+ *
+ * @package     mod_edflex
+ * @copyright   2025 Edflex <support@edflex.com>
+ * @license     https://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+class backup_edflex_activity_task extends backup_activity_task {
+
+    /**
+     * Defines particular settings for this activity task. None required.
+     *
+     * @return void
+     */
+    protected function define_my_settings() {
+    }
+
+    /**
+     * Defines particular steps for this activity backup.
+     *
+     * @return void
+     */
+    protected function define_my_steps() {
+        $this->add_step(new backup_edflex_activity_structure_step('edflex_structure', 'edflex.xml'));
+    }
+
+    /**
+     * Encodes URLs to the view and index scripts so they can be decoded on restore.
+     *
+     * @param string $content The content to encode.
+     *
+     * @return string The content with encoded links.
+     */
+    public static function encode_content_links($content) {
+        global $CFG;
+
+        $base = preg_quote($CFG->wwwroot, '/');
+
+        $search = '/(' . $base . '\/mod\/edflex\/view\.php\?id\=)([0-9]+)/';
+        $content = preg_replace($search, '$@EDFLEXVIEWBYID*$2@$', $content);
+
+        $search = '/(' . $base . '\/mod\/edflex\/index\.php\?id\=)([0-9]+)/';
+        $content = preg_replace($search, '$@EDFLEXINDEX*$2@$', $content);
+
+        return $content;
+    }
+}

--- a/backup/moodle2/backup_edflex_activity_task.class.php
+++ b/backup/moodle2/backup_edflex_activity_task.class.php
@@ -34,7 +34,6 @@ require_once($CFG->dirroot . '/mod/edflex/backup/moodle2/backup_edflex_stepslib.
  * @license     https://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 class backup_edflex_activity_task extends backup_activity_task {
-
     /**
      * Defines particular settings for this activity task. None required.
      *

--- a/backup/moodle2/backup_edflex_stepslib.php
+++ b/backup/moodle2/backup_edflex_stepslib.php
@@ -1,0 +1,52 @@
+<?php
+// This file is part of Moodle - https://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <https://www.gnu.org/licenses/>.
+
+/**
+ * Backup steps for mod_edflex.
+ *
+ * @package     mod_edflex
+ * @copyright   2025 Edflex <support@edflex.com>
+ * @license     https://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+defined('MOODLE_INTERNAL') || die();
+
+/**
+ * Defines the complete edflex structure for backup, with file annotations.
+ *
+ * @package     mod_edflex
+ * @copyright   2025 Edflex <support@edflex.com>
+ * @license     https://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+class backup_edflex_activity_structure_step extends backup_activity_structure_step {
+
+    /**
+     * Defines the backup structure of the edflex activity.
+     *
+     * @return backup_nested_element The prepared activity structure to back up.
+     */
+    protected function define_structure() {
+        $edflex = new backup_nested_element('edflex', ['id'], [
+            'name', 'intro', 'introformat', 'timemodified',
+        ]);
+
+        $edflex->set_source_table('edflex', ['id' => backup::VAR_ACTIVITYID]);
+
+        $edflex->annotate_files('mod_edflex', 'intro', null);
+
+        return $this->prepare_activity_structure($edflex);
+    }
+}

--- a/backup/moodle2/backup_edflex_stepslib.php
+++ b/backup/moodle2/backup_edflex_stepslib.php
@@ -22,8 +22,6 @@
  * @license     https://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
-defined('MOODLE_INTERNAL') || die();
-
 /**
  * Defines the complete edflex structure for backup, with file annotations.
  *
@@ -32,7 +30,6 @@ defined('MOODLE_INTERNAL') || die();
  * @license     https://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 class backup_edflex_activity_structure_step extends backup_activity_structure_step {
-
     /**
      * Defines the backup structure of the edflex activity.
      *

--- a/backup/moodle2/restore_edflex_activity_task.class.php
+++ b/backup/moodle2/restore_edflex_activity_task.class.php
@@ -1,0 +1,91 @@
+<?php
+// This file is part of Moodle - https://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <https://www.gnu.org/licenses/>.
+
+/**
+ * Restore task for mod_edflex.
+ *
+ * @package     mod_edflex
+ * @copyright   2025 Edflex <support@edflex.com>
+ * @license     https://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+defined('MOODLE_INTERNAL') || die();
+
+require_once($CFG->dirroot . '/mod/edflex/backup/moodle2/restore_edflex_stepslib.php');
+
+/**
+ * Restore task for the edflex activity module.
+ *
+ * @package     mod_edflex
+ * @copyright   2025 Edflex <support@edflex.com>
+ * @license     https://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+class restore_edflex_activity_task extends restore_activity_task {
+
+    /**
+     * Defines particular settings for this activity task. None required.
+     *
+     * @return void
+     */
+    protected function define_my_settings() {
+    }
+
+    /**
+     * Defines particular steps for this activity restore.
+     *
+     * @return void
+     */
+    protected function define_my_steps() {
+        $this->add_step(new restore_edflex_activity_structure_step('edflex_structure', 'edflex.xml'));
+    }
+
+    /**
+     * Defines the contents in the activity that must be processed by the link decoder.
+     *
+     * @return array The decode contents.
+     */
+    public static function define_decode_contents() {
+        $contents = [];
+        $contents[] = new restore_decode_content('edflex', ['intro'], 'edflex');
+
+        return $contents;
+    }
+
+    /**
+     * Defines the decoding rules for links belonging to the activity to be executed by the link decoder.
+     *
+     * @return array The decode rules.
+     */
+    public static function define_decode_rules() {
+        $rules = [];
+        $rules[] = new restore_decode_rule('EDFLEXVIEWBYID', '/mod/edflex/view.php?id=$1', 'course_module');
+        $rules[] = new restore_decode_rule('EDFLEXINDEX', '/mod/edflex/index.php?id=$1', 'course');
+
+        return $rules;
+    }
+
+    /**
+     * Defines the restore log rules that will be applied for the activity logs.
+     *
+     * @return array The restore log rules.
+     */
+    public static function define_restore_log_rules() {
+        $rules = [];
+        $rules[] = new restore_log_rule('edflex', 'view', 'view.php?id={course_module}', '{edflex}');
+
+        return $rules;
+    }
+}

--- a/backup/moodle2/restore_edflex_activity_task.class.php
+++ b/backup/moodle2/restore_edflex_activity_task.class.php
@@ -34,7 +34,6 @@ require_once($CFG->dirroot . '/mod/edflex/backup/moodle2/restore_edflex_stepslib
  * @license     https://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 class restore_edflex_activity_task extends restore_activity_task {
-
     /**
      * Defines particular settings for this activity task. None required.
      *

--- a/backup/moodle2/restore_edflex_stepslib.php
+++ b/backup/moodle2/restore_edflex_stepslib.php
@@ -22,8 +22,6 @@
  * @license     https://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
-defined('MOODLE_INTERNAL') || die();
-
 /**
  * Defines the structure step to restore one edflex activity.
  *
@@ -32,7 +30,6 @@ defined('MOODLE_INTERNAL') || die();
  * @license     https://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 class restore_edflex_activity_structure_step extends restore_activity_structure_step {
-
     /**
      * Defines the structure to be restored for the edflex activity.
      *

--- a/backup/moodle2/restore_edflex_stepslib.php
+++ b/backup/moodle2/restore_edflex_stepslib.php
@@ -1,0 +1,74 @@
+<?php
+// This file is part of Moodle - https://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <https://www.gnu.org/licenses/>.
+
+/**
+ * Restore steps for mod_edflex.
+ *
+ * @package     mod_edflex
+ * @copyright   2025 Edflex <support@edflex.com>
+ * @license     https://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+defined('MOODLE_INTERNAL') || die();
+
+/**
+ * Defines the structure step to restore one edflex activity.
+ *
+ * @package     mod_edflex
+ * @copyright   2025 Edflex <support@edflex.com>
+ * @license     https://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+class restore_edflex_activity_structure_step extends restore_activity_structure_step {
+
+    /**
+     * Defines the structure to be restored for the edflex activity.
+     *
+     * @return mixed The prepared activity structure.
+     */
+    protected function define_structure() {
+        $paths = [];
+        $paths[] = new restore_path_element('edflex', '/activity/edflex');
+
+        return $this->prepare_activity_structure($paths);
+    }
+
+    /**
+     * Restores one edflex instance from the backup data.
+     *
+     * @param array $data The edflex record to restore.
+     *
+     * @return void
+     */
+    protected function process_edflex($data) {
+        global $DB;
+
+        $data = (object) $data;
+        $data->course = $this->get_courseid();
+        $data->timemodified = $this->apply_date_offset($data->timemodified);
+
+        $newitemid = $DB->insert_record('edflex', $data);
+        $this->apply_activity_instance($newitemid);
+    }
+
+    /**
+     * Re-adds the files belonging to the restored instance once execution completes.
+     *
+     * @return void
+     */
+    protected function after_execute() {
+        $this->add_related_files('mod_edflex', 'intro', null);
+    }
+}

--- a/classes/event/course_module_viewed.php
+++ b/classes/event/course_module_viewed.php
@@ -24,8 +24,6 @@
 
 namespace mod_edflex\event;
 
-defined('MOODLE_INTERNAL') || die();
-
 /**
  * The mod_edflex course module viewed event class.
  *
@@ -34,7 +32,6 @@ defined('MOODLE_INTERNAL') || die();
  * @license     https://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 class course_module_viewed extends \core\event\course_module_viewed {
-
     /**
      * Init method.
      *

--- a/classes/event/course_module_viewed.php
+++ b/classes/event/course_module_viewed.php
@@ -15,20 +15,43 @@
 // along with Moodle.  If not, see <https://www.gnu.org/licenses/>.
 
 /**
- * Plugin version and other meta-data are defined here.
+ * The mod_edflex course module viewed event.
  *
  * @package     mod_edflex
  * @copyright   2025 Edflex <support@edflex.com>
  * @license     https://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
+namespace mod_edflex\event;
+
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->component = 'mod_edflex';
-$plugin->release = 'v1.0.2';
-$plugin->version = 2026062900;
-$plugin->requires = 2022041900;
-$plugin->maturity = MATURITY_STABLE;
-$plugin->dependencies = [
-    'mod_scorm' => ANY_VERSION,
-];
+/**
+ * The mod_edflex course module viewed event class.
+ *
+ * @package     mod_edflex
+ * @copyright   2025 Edflex <support@edflex.com>
+ * @license     https://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+class course_module_viewed extends \core\event\course_module_viewed {
+
+    /**
+     * Init method.
+     *
+     * @return void
+     */
+    protected function init() {
+        $this->data['crud'] = 'r';
+        $this->data['edulevel'] = self::LEVEL_PARTICIPATING;
+        $this->data['objecttable'] = 'edflex';
+    }
+
+    /**
+     * Returns the mapping used by restore to remap the objectid.
+     *
+     * @return array The objectid mapping.
+     */
+    public static function get_objectid_mapping() {
+        return ['db' => 'edflex', 'restore' => 'edflex'];
+    }
+}

--- a/db/access.php
+++ b/db/access.php
@@ -31,4 +31,15 @@ $capabilities = [
         'contextlevel' => CONTEXT_COURSE,
         'archetypes' => ['editingteacher' => CAP_ALLOW, 'manager' => CAP_ALLOW],
     ],
+    'mod/edflex:view' => [
+        'captype' => 'read',
+        'contextlevel' => CONTEXT_MODULE,
+        'archetypes' => [
+            'guest' => CAP_ALLOW,
+            'student' => CAP_ALLOW,
+            'teacher' => CAP_ALLOW,
+            'editingteacher' => CAP_ALLOW,
+            'manager' => CAP_ALLOW,
+        ],
+    ],
 ];

--- a/lang/en/edflex.php
+++ b/lang/en/edflex.php
@@ -60,6 +60,7 @@ $string['difficultyintroductive'] = 'Introductive';
 $string['downloadscormzipmissing'] = 'Scorm download URL is missing';
 $string['duration'] = 'Duration';
 $string['edflex:addinstance'] = 'Add a new Edflex activity';
+$string['edflex:view'] = 'View Edflex activity';
 $string['edflexbrowserloading'] = 'Loading...';
 $string['edflexbrowsertitle'] = 'Browse Edflex Contents';
 $string['edflexcontentidinvalid'] = 'Edflex content ID invalid';

--- a/lib.php
+++ b/lib.php
@@ -36,7 +36,14 @@ global $CFG;
  * @return mixed True if module supports feature, null if doesn't know
  */
 function edflex_supports($feature) {
-    return null;
+    switch ($feature) {
+        case FEATURE_MOD_INTRO:
+        case FEATURE_SHOW_DESCRIPTION:
+        case FEATURE_BACKUP_MOODLE2:
+            return true;
+        default:
+            return null;
+    }
 }
 
 /**
@@ -48,6 +55,8 @@ function edflex_supports($feature) {
  * @return bool
  */
 function edflex_add_instance($moduleinstance, $mform = null) {
+    // mod_edflex is a launcher only: the form spawns SCORM modules via the
+    // Edflex browser, so no standalone edflex instance is ever persisted.
     return false;
 }
 

--- a/lib.php
+++ b/lib.php
@@ -55,7 +55,7 @@ function edflex_supports($feature) {
  * @return bool
  */
 function edflex_add_instance($moduleinstance, $mform = null) {
-    // mod_edflex is a launcher only: the form spawns SCORM modules via the
+    // The mod_edflex form is a launcher: it spawns SCORM modules via the
     // Edflex browser, so no standalone edflex instance is ever persisted.
     return false;
 }

--- a/view.php
+++ b/view.php
@@ -26,8 +26,26 @@ require_once(__DIR__ . '/../../config.php');
 $id = required_param('id', PARAM_INT);
 $cm = get_coursemodule_from_id('edflex', $id, 0, false, MUST_EXIST);
 $course = $DB->get_record('course', ['id' => $cm->course], '*', MUST_EXIST);
+$moduleinstance = $DB->get_record('edflex', ['id' => $cm->instance], '*', MUST_EXIST);
 
 require_login($course, true, $cm);
+
+$context = context_module::instance($cm->id);
+require_capability('mod/edflex:view', $context);
+
+$PAGE->set_url('/mod/edflex/view.php', ['id' => $cm->id]);
+$PAGE->set_title(format_string($moduleinstance->name));
+$PAGE->set_heading(format_string($course->fullname));
+$PAGE->set_context($context);
+
+$event = \mod_edflex\event\course_module_viewed::create([
+    'objectid' => $moduleinstance->id,
+    'context' => $context,
+]);
+$event->add_record_snapshot('course', $course);
+$event->add_record_snapshot('course_modules', $cm);
+$event->add_record_snapshot('edflex', $moduleinstance);
+$event->trigger();
 
 echo $OUTPUT->header();
 echo $OUTPUT->heading(get_string('outputheading', 'mod_edflex'));


### PR DESCRIPTION
## 🎯 Purpose of this Pull Request

The Moodle Marketplace review of `mod_edflex` (review ticket MMRT-99) returned three approval blockers. This PR addresses all three so the plugin can be resubmitted.

1. **BLOCKER** — activity module missing the Backup/Restore API.
2. **HIGH** — inadequate capability checking in `view.php` (`require_login` present, no `require_capability`).
3. **HIGH** — missing the standard `course_module_viewed` event.

---

## 📝 Summary of Changes

- Implement the moodle2 Backup/Restore API for the `edflex` activity (`backup/moodle2/`: backup + restore task classes and stepslibs), covering the `edflex` table and `intro` files.
- Add a `mod/edflex:view` capability and enforce it with `require_capability()` in `view.php`; set the page url/context/title/heading before output.
- Add `\mod_edflex\event\course_module_viewed` and trigger it from `view.php`.
- Declare `FEATURE_MOD_INTRO`, `FEATURE_SHOW_DESCRIPTION`, `FEATURE_BACKUP_MOODLE2` in `edflex_supports()`; bump `version.php` to `v1.0.2`.

---

## ✔️ Moodle Plugin Checklist

### **Code Quality & Standards**
- [x] Code follows Moodle coding guidelines
- [x] PHPDoc blocks updated where needed
- [x] No debug statements left
- [x] Namespace and file structure follow Moodle plugin conventions

### **Functional Changes**
- [x] New strings added to `lang/en/edflex.php` (`edflex:view`)
- [x] Capabilities added/updated in `db/access.php`
- [x] Backup/restore updated

### **Database & Files**
- [x] Privacy API unchanged — plugin still stores no personal data

---

## 🧪 Testing

### **Manual Tests**
- Back up a course containing an Edflex activity → backup completes without error.
- Restore that backup into another course → the instance is recreated with its settings.
- Open the activity view page → access is denied without `mod/edflex:view`, and a `course_module_viewed` event is logged.

### **Automated Tests**
- [ ] PHPUnit tests not added in this PR

---

## 🔄 Regression Risk

`view.php` access path (new capability gate + event) and the new backup/restore steps. No change to the SCORM-wrapper flow.

---

## 🔗 Additional Notes

- `mod_edflex` is a **launcher**: `edflex_add_instance()` returns `false` by design (the form spawns SCORM modules via the Edflex browser), so no standalone `edflex` instance is persisted. The Backup/Restore API is implemented to satisfy the Marketplace requirement and is correct, but inert until/unless real instances exist.
- Known follow-up: `edflex_scorm` rows are not carried through a course restore — preserving them would require a `mod_scorm` backup subplugin. Out of scope here.