### PR TITLE
🔖 Bump plugin version

### DIFF
--- a/version.php
+++ b/version.php
@@ -26,7 +26,7 @@ defined('MOODLE_INTERNAL') || die();
 
 $plugin->component = 'mod_edflex';
 $plugin->release = 'v1.0.2';
-$plugin->version = 2026062900;
+$plugin->version = 2026062901;
 $plugin->requires = 2022041900;
 $plugin->maturity = MATURITY_STABLE;
 $plugin->dependencies = [


### PR DESCRIPTION
## 🎯 Purpose

Bump the plugin version so Moodle picks up the changes already on `main` (CI rework + the pgsql/ESLint fixes from #8) as an upgrade.

## 📝 Summary of Changes

- `version.php`: `$plugin->version` `2026062900` → `2026062901` (release stays `v1.0.2`).
