### PR TITLE
🐛 Migrate before_footer callback to Moodle hook

### DIFF
--- a/classes/hook_callbacks.php
+++ b/classes/hook_callbacks.php
@@ -1,0 +1,55 @@
+<?php
+// This file is part of Moodle - https://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <https://www.gnu.org/licenses/>.
+
+namespace mod_edflex;
+
+use core\hook\output\before_footer_html_generation;
+use mod_edflex\output\edflex_scorm;
+
+/**
+ * Hook callbacks for mod_edflex.
+ *
+ * @package     mod_edflex
+ * @copyright   2025 Edflex <support@edflex.com>
+ * @license     https://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+class hook_callbacks {
+    /**
+     * Add edflex content before the footer on SCORM module pages.
+     *
+     * @param before_footer_html_generation $hook
+     */
+    public static function before_footer_html_generation(before_footer_html_generation $hook): void {
+        $hook->add_html(self::scorm_footer_html());
+    }
+
+    /**
+     * Render the edflex content injected before the footer on SCORM module pages.
+     *
+     * @return string|null Rendered HTML, or null when the current page is not a mapped edflex SCORM.
+     */
+    public static function scorm_footer_html(): ?string {
+        global $PAGE, $DB, $OUTPUT;
+
+        if ($PAGE->cm && $PAGE->cm->modname === 'scorm') {
+            if ($edflex = $DB->get_record('edflex_scorm', ['scormid' => $PAGE->cm->instance])) {
+                return $OUTPUT->render(new edflex_scorm($edflex));
+            }
+        }
+
+        return null;
+    }
+}

--- a/db/hooks.php
+++ b/db/hooks.php
@@ -15,7 +15,7 @@
 // along with Moodle.  If not, see <https://www.gnu.org/licenses/>.
 
 /**
- * Plugin version and other meta-data are defined here.
+ * Hook callbacks.
  *
  * @package     mod_edflex
  * @copyright   2025 Edflex <support@edflex.com>
@@ -24,11 +24,9 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->component = 'mod_edflex';
-$plugin->release = 'v1.0.3';
-$plugin->version = 2026070600;
-$plugin->requires = 2022041900;
-$plugin->maturity = MATURITY_STABLE;
-$plugin->dependencies = [
-    'mod_scorm' => ANY_VERSION,
+$callbacks = [
+    [
+        'hook' => \core\hook\output\before_footer_html_generation::class,
+        'callback' => \mod_edflex\hook_callbacks::class . '::before_footer_html_generation',
+    ],
 ];

--- a/lib.php
+++ b/lib.php
@@ -142,20 +142,13 @@ function mod_edflex_inject_browser_javascript() {
 }
 
 /**
- * Render additional content before the footer in SCORM module pages.
+ * Legacy before_footer callback for Moodle < 4.4.
  *
- * Checks if the current course module is a SCORM activity and retrieves
- * associated edflex information from the database. If a record is found,
- * it outputs the rendered content using the appropriate renderer.
+ * On Moodle 4.4+ the {@see \core\hook\output\before_footer_html_generation} hook
+ * registered in db/hooks.php supersedes this and this function is not called.
+ *
+ * @return string|null
  */
 function mod_edflex_before_footer() {
-    global $PAGE, $DB, $OUTPUT;
-
-    if ($PAGE->cm && $PAGE->cm->modname === 'scorm') {
-        $scormid = $PAGE->cm->instance;
-
-        if ($edflex = $DB->get_record('edflex_scorm', ['scormid' => $scormid])) {
-            echo $OUTPUT->render(new edflex_scorm($edflex));
-        }
-    }
+    return \mod_edflex\hook_callbacks::scorm_footer_html();
 }


### PR DESCRIPTION
# 📋 Summary

- The legacy `before_footer` plugin callback triggers a deprecation notice on Moodle 4.4+ (`core\hook\output\before_footer_html_generation->process_legacy_callbacks`).
- Register the hook in `db/hooks.php` so the notice is suppressed and the callback runs through the new hook API.
- Keep `mod_edflex_before_footer()` (now returning its HTML) as a fallback for Moodle < 4.4.

# 🧪 Manual checks

- [ ] On a Moodle 4.5 site, open a SCORM activity with an edflex mapping: the edflex block still renders and no "should be migrated to new hook callback" debug notice appears.